### PR TITLE
Fix cmake install dirs

### DIFF
--- a/cmake/Translations.cmake
+++ b/cmake/Translations.cmake
@@ -20,7 +20,7 @@ macro (add_translations_directory NLS_PACKAGE)
         add_custom_command (TARGET i18n COMMAND ${MSGFMT_EXECUTABLE} -o ${MO_OUTPUT} ${PO_INPUT})
 
         install (FILES ${MO_OUTPUT} DESTINATION
-            share/locale/${PO_INPUT_BASE}/LC_MESSAGES
+            ${CMAKE_INSTALL_DATAROOTDIR}/locale/${PO_INPUT_BASE}/LC_MESSAGES
             RENAME ${NLS_PACKAGE}.mo
             COMPONENT ${ARGV1})
     endforeach (PO_INPUT ${PO_FILES})

--- a/cmake/TranslationsMusl.cmake
+++ b/cmake/TranslationsMusl.cmake
@@ -20,6 +20,6 @@ macro (add_musl_translations_directory NLS_PACKAGE LOCPATH)
         add_custom_command (TARGET musl-i18n COMMAND ${MSGFMT_EXECUTABLE} -o ${MO_OUTPUT} ${PO_INPUT})
 
         install (FILES ${MO_OUTPUT} DESTINATION
-            ${LOCPATH})
+            ${CMAKE_INSTALL_DATAROOTDIR}/${LOCPATH})
     endforeach (PO_INPUT ${PO_FILES})
 endmacro (add_musl_translations_directory)


### PR DESCRIPTION
CMAKE_INSTALL_DATAROOTDIR expands to /usr/share, this is the standard locale path (/usr/share/locale and /usr/share/i18n/locales)