### PR TITLE
add german de_DE locale

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,17 @@
 project(locales C)
 cmake_minimum_required(VERSION 2.8)
+
+option(LOCALE_PROFILE "Install profile file setting the MUSL_LOCPATH environment variable" ON)
+
 include(GNUInstallDirs)
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 set(GETTEXT_PACKAGE "musl-locales")
 set(MUSL_LOCPATH i18n/locales/musl CACHE PATH "Locales directory" FORCE)
 configure_file(config.h.in config.h)
-configure_file(locale.in 00locale.sh)
+if(LOCALE_PROFILE)
+  configure_file(locale.in 00locale.sh)
+endif(LOCALE_PROFILE)
 find_package(Intl)
 set(LOCALE_SOURCES locale.c categories.c categories.h config.h)
 add_executable(locale ${LOCALE_SOURCES})
@@ -16,8 +21,10 @@ endif()
 target_compile_options(locale
   PRIVATE $<$<COMPILE_LANGUAGE:C>:-std=gnu11 -Wno-pedantic>
 )
-install(PROGRAMS ${CMAKE_BINARY_DIR}/00locale.sh DESTINATION 
-"${CMAKE_INSTALL_FULL_SYSCONFDIR}/profile.d")
+if(LOCALE_PROFILE)
+  install(PROGRAMS ${CMAKE_BINARY_DIR}/00locale.sh DESTINATION 
+  "${CMAKE_INSTALL_FULL_SYSCONFDIR}/profile.d")
+endif(LOCALE_PROFILE)
 install(TARGETS locale DESTINATION bin)
 add_subdirectory(po)
 add_subdirectory(musl-po)

--- a/musl-po/de_DE.po
+++ b/musl-po/de_DE.po
@@ -1,0 +1,195 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Language: de_DE\n"
+"X-Source-Language: C\n"
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:89
+#, c-format
+msgid "%2d"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:92
+msgid "%Y-%m-%d"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:141
+msgid "\t"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:174
+#, c-format
+msgid "+%lld"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:184
+#, c-format
+msgid "%+.2d%.2d"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:202
+#, c-format
+msgid "%0*lld"
+msgstr ""
+
+msgid "Sun"
+msgstr "So"
+
+msgid "Mon"
+msgstr "Mo"
+
+msgid "Tue"
+msgstr "Di"
+
+msgid "Wed"
+msgstr "Mi"
+
+msgid "Thu"
+msgstr "Do"
+
+msgid "Fri"
+msgstr "Fr"
+
+msgid "Sat"
+msgstr "Sa"
+
+msgid "Sunday"
+msgstr "Sonntag"
+
+msgid "Monday"
+msgstr "Montag"
+
+msgid "Tuesday"
+msgstr "Dienstag"
+
+msgid "Wednesday"
+msgstr "Mittwoch"
+
+msgid "Thursday"
+msgstr "Donnerstag"
+
+msgid "Friday"
+msgstr "Freitag"
+
+msgid "Saturday"
+msgstr "Samstag"
+
+msgid "Jan"
+msgstr ""
+
+msgid "Feb"
+msgstr ""
+
+msgid "Mar"
+msgstr "Mär"
+
+msgid "Apr"
+msgstr ""
+
+msgid "May"
+msgstr "Mai"
+
+msgid "Jun"
+msgstr ""
+
+msgid "Jul"
+msgstr ""
+
+msgid "Aug"
+msgstr ""
+
+msgid "Sep"
+msgstr "Sept"
+
+msgid "Oct"
+msgstr "Okt"
+
+msgid "Nov"
+msgstr ""
+
+msgid "Dec"
+msgstr "Dez"
+
+msgid "January"
+msgstr "Januar"
+
+msgid "February"
+msgstr "Februar"
+
+msgid "March"
+msgstr "März"
+
+msgid "April"
+msgstr ""
+
+msgid "June"
+msgstr "Juni"
+
+msgid "July"
+msgstr "Juli"
+
+msgid "August"
+msgstr ""
+
+msgid "September"
+msgstr ""
+
+msgid "October"
+msgstr "Oktober"
+
+msgid "November"
+msgstr ""
+
+msgid "December"
+msgstr "Dezember"
+
+msgid "AM"
+msgstr ""
+
+msgid "PM"
+msgstr ""
+
+msgid "%a %b %e %T %Y"
+msgstr "%a %d %b %Y %T %Z"
+
+#: ../musl/musl-1.1.14/src/time/strptime.c:54
+#: ../musl/musl-1.1.14/src/time/strftime.c:86
+msgid "%m/%d/%y"
+msgstr "%d.%m.%y"
+
+#: ../musl/musl-1.1.14/src/time/strptime.c:106
+#: ../musl/musl-1.1.14/src/time/strftime.c:130
+msgid "%H:%M"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strptime.c:115
+#: ../musl/musl-1.1.14/src/time/strftime.c:143
+msgid "%H:%M:%S"
+msgstr ""
+
+msgid "%I:%M:%S %p"
+msgstr ""
+
+msgid "0123456789"
+msgstr ""
+
+msgid "%a %b %e %T %Y %Z"
+msgstr ""
+
+msgid "^[yY]"
+msgstr "^[+1jJyY]"
+
+msgid "^[nN]"
+msgstr ""
+
+msgid "yes"
+msgstr "ja"
+
+msgid "no"
+msgstr "nein"
+
+msgid "."
+msgstr ","

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -1,0 +1,195 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Language: de_DE\n"
+"X-Source-Language: C\n"
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:89
+#, c-format
+msgid "%2d"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:92
+msgid "%Y-%m-%d"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:141
+msgid "\t"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:174
+#, c-format
+msgid "+%lld"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:184
+#, c-format
+msgid "%+.2d%.2d"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strftime.c:202
+#, c-format
+msgid "%0*lld"
+msgstr ""
+
+msgid "Sun"
+msgstr "So"
+
+msgid "Mon"
+msgstr "Mo"
+
+msgid "Tue"
+msgstr "Di"
+
+msgid "Wed"
+msgstr "Mi"
+
+msgid "Thu"
+msgstr "Do"
+
+msgid "Fri"
+msgstr "Fr"
+
+msgid "Sat"
+msgstr "Sa"
+
+msgid "Sunday"
+msgstr "Sonntag"
+
+msgid "Monday"
+msgstr "Montag"
+
+msgid "Tuesday"
+msgstr "Dienstag"
+
+msgid "Wednesday"
+msgstr "Mittwoch"
+
+msgid "Thursday"
+msgstr "Donnerstag"
+
+msgid "Friday"
+msgstr "Freitag"
+
+msgid "Saturday"
+msgstr "Samstag"
+
+msgid "Jan"
+msgstr ""
+
+msgid "Feb"
+msgstr ""
+
+msgid "Mar"
+msgstr "Mär"
+
+msgid "Apr"
+msgstr ""
+
+msgid "May"
+msgstr "Mai"
+
+msgid "Jun"
+msgstr ""
+
+msgid "Jul"
+msgstr ""
+
+msgid "Aug"
+msgstr ""
+
+msgid "Sep"
+msgstr "Sept"
+
+msgid "Oct"
+msgstr "Okt"
+
+msgid "Nov"
+msgstr ""
+
+msgid "Dec"
+msgstr "Dez"
+
+msgid "January"
+msgstr "Januar"
+
+msgid "February"
+msgstr "Februar"
+
+msgid "March"
+msgstr "März"
+
+msgid "April"
+msgstr ""
+
+msgid "June"
+msgstr "Juni"
+
+msgid "July"
+msgstr "Juli"
+
+msgid "August"
+msgstr ""
+
+msgid "September"
+msgstr ""
+
+msgid "October"
+msgstr "Oktober"
+
+msgid "November"
+msgstr ""
+
+msgid "December"
+msgstr "Dezember"
+
+msgid "AM"
+msgstr ""
+
+msgid "PM"
+msgstr ""
+
+msgid "%a %b %e %T %Y"
+msgstr "%a %d %b %Y %T %Z"
+
+#: ../musl/musl-1.1.14/src/time/strptime.c:54
+#: ../musl/musl-1.1.14/src/time/strftime.c:86
+msgid "%m/%d/%y"
+msgstr "%d.%m.%y"
+
+#: ../musl/musl-1.1.14/src/time/strptime.c:106
+#: ../musl/musl-1.1.14/src/time/strftime.c:130
+msgid "%H:%M"
+msgstr ""
+
+#: ../musl/musl-1.1.14/src/time/strptime.c:115
+#: ../musl/musl-1.1.14/src/time/strftime.c:143
+msgid "%H:%M:%S"
+msgstr ""
+
+msgid "%I:%M:%S %p"
+msgstr ""
+
+msgid "0123456789"
+msgstr ""
+
+msgid "%a %b %e %T %Y %Z"
+msgstr ""
+
+msgid "^[yY]"
+msgstr "^[+1jJyY]"
+
+msgid "^[nN]"
+msgstr ""
+
+msgid "yes"
+msgstr "ja"
+
+msgid "no"
+msgstr "nein"
+
+msgid "."
+msgstr ","


### PR DESCRIPTION
I added a german de_DE locale, based on the swiss one, but extended and completed. My main focus was on the time and date strings, so I left most other strings untranslated